### PR TITLE
Removed superflous await call to base class in IntegratedTokenCacheAd…

### DIFF
--- a/1-Integrated-Cache/IntegratedCacheUtils/IntegratedTokenCacheAdapter.cs
+++ b/1-Integrated-Cache/IntegratedCacheUtils/IntegratedTokenCacheAdapter.cs
@@ -35,8 +35,6 @@ namespace IntegratedCacheUtils
             await UpsertActivity(accountActivity);
 
             _logger.LogInformation($"{args.SuggestedCacheKey}-{args.Account}");
-
-            await Task.FromResult(base.OnBeforeWriteAsync(args));
         }
 
         // Call the upsert method of the class that implements IMsalAccountActivityStore


### PR DESCRIPTION
## Purpose
Remove a superfluous await call to resolve [issue 13](https://github.com/Azure-Samples/ms-identity-dotnet-advanced-token-cache/issues/13).

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

Removes a superfluous await call in **IntegratedCacheUtils/IntegratedTokenCacheAdapter.cs**. Bug was innocuous but removed here for code hygiene.

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
* Smoke test that code runs like before. There should be no behavioral changes.

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
# Follow instructions in README
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* Code runs same as before.

## Other Information
<!-- Add any other helpful information that may be needed here. -->